### PR TITLE
Fixed list type of system state

### DIFF
--- a/lib/src/ros_xmlrpc_client.dart
+++ b/lib/src/ros_xmlrpc_client.dart
@@ -315,15 +315,27 @@ mixin RosXmlRpcClient on XmlRpcClient {
     return SystemState(
       [
         for (final pubInfo in resp[0])
-          PublisherInfo(pubInfo[0] as String, pubInfo[1] as List<String>)
+          PublisherInfo(pubInfo[0] as String,
+              [
+                for (final publisher in pubInfo[1])
+                  publisher as String
+              ])
       ],
       [
         for (final subInfo in resp[1])
-          SubscriberInfo(subInfo[0] as String, subInfo[1] as List<String>)
+          SubscriberInfo(subInfo[0] as String,
+              [
+                for (final subscriber in subInfo[1])
+                  subsciber as String
+              ])
       ],
       [
         for (final servInfo in resp[2])
-          ServiceInfo(servInfo[0] as String, servInfo[1] as List<String>)
+          ServiceInfo(servInfo[0] as String,
+              [
+                for (final serviceProvider in servInfo[1])
+                  serviceProvider as String
+              ])
       ],
     );
   }

--- a/lib/src/ros_xmlrpc_client.dart
+++ b/lib/src/ros_xmlrpc_client.dart
@@ -326,7 +326,7 @@ mixin RosXmlRpcClient on XmlRpcClient {
           SubscriberInfo(subInfo[0] as String,
               [
                 for (final subscriber in subInfo[1])
-                  subsciber as String
+                  subscriber as String
               ])
       ],
       [


### PR DESCRIPTION
## Env
- System: Ubuntu20.04
- Flutter: v3.3.9
- Dart: v2.18.5

## Problem
When use the `node.getSystemState()` function, it occurs the error:
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type 'List<Object?>' is not a subtype of type 'List<String>' in type cast
#0      RosXmlRpcClient.getSystemState (package:dartros/src/ros_xmlrpc_client.dart:318:58)
<asynchronous suspension>
```

## Fixed
The reason is that dart can not directly convert `List<Object?>`  to  `List<String?>`, I have used another way to implement the convertion.